### PR TITLE
fix 1v1 being stuck after a revive or buy phase

### DIFF
--- a/src/app/components/combat/1v1/1v1.component.ts
+++ b/src/app/components/combat/1v1/1v1.component.ts
@@ -1,9 +1,10 @@
-import { Component, computed, effect, inject, OnInit, signal } from "@angular/core";
+import { Component, computed, inject, OnInit } from "@angular/core";
 import { SafeResourceUrl } from "@angular/platform-browser";
 import { DataModelService } from "../../../services/dataModel.service";
 import { PlayerCombatCardComponent } from "../player-combat-card/player-combat-card.component";
 import { DisplayNameService } from "../../../services/displayName.service";
 import { PlayercamStreamService } from "../../../services/playercamStream.service";
+import { OneVersusOneService } from "../../../services/1v1.service";
 
 @Component({
   selector: "app-1v1",
@@ -15,74 +16,14 @@ export class OneVersusOneComponent implements OnInit {
   dataModel = inject(DataModelService);
   getDisplayName = inject(DisplayNameService).getDisplayName;
   readonly streamService = inject(PlayercamStreamService);
+  readonly oneVsOneService = inject(OneVersusOneService);
 
-  private lastRoundNumber = signal<number>(-1);
-  private oneVersusOneTriggered = signal<boolean>(false);
-  private storedLeftPlayer = signal<any>(null);
-  private storedRightPlayer = signal<any>(null);
-  private storedLeftPlayerIndex = signal<number>(2);
-  private storedRightPlayerIndex = signal<number>(2);
-
-  constructor() {
-    effect(() => {
-      const currentRound = this.dataModel.match().roundNumber;
-      const previousRound = this.lastRoundNumber();
-
-      if (currentRound !== previousRound) {
-        this.oneVersusOneTriggered.set(false);
-        this.storedLeftPlayer.set(null);
-        this.storedRightPlayer.set(null);
-        this.storedLeftPlayerIndex.set(2);
-        this.storedRightPlayerIndex.set(2);
-        this.lastRoundNumber.set(currentRound);
-      }
-
-      const teams = this.dataModel.teams();
-      const aliveLeft = teams[0].players.filter((p: any) => p.isAlive).length;
-      const aliveRight = teams[1].players.filter((p: any) => p.isAlive).length;
-
-      if (aliveLeft === 1 && aliveRight === 1) {
-        this.oneVersusOneTriggered.set(true);
-        // Store the players and their indices when 1v1 triggers
-        const leftPlayerIndex = teams[0].players.findIndex((p: any) => p.isAlive);
-        const rightPlayerIndex = teams[1].players.findIndex((p: any) => p.isAlive);
-        const leftPlayer = teams[0].players[leftPlayerIndex];
-        const rightPlayer = teams[1].players[rightPlayerIndex];
-        if (leftPlayer) {
-          this.storedLeftPlayer.set(leftPlayer);
-          this.storedLeftPlayerIndex.set(leftPlayerIndex);
-        }
-        if (rightPlayer) {
-          this.storedRightPlayer.set(rightPlayer);
-          this.storedRightPlayerIndex.set(rightPlayerIndex);
-        }
-      }
-      if (this.oneVersusOneTriggered() && (aliveLeft >= 2 || aliveRight >= 2)) {
-        this.oneVersusOneTriggered.set(false);
-      }
-    });
-  }
-
-  isOneVersusOne = computed(() => this.oneVersusOneTriggered());
-
-  leftPlayer = computed(() => {
-    if (this.isOneVersusOne()) {
-      const index = this.storedLeftPlayerIndex();
-      return this.dataModel.teams()[0]?.players[index] || null;
-    }
-    return this.dataModel.teams()[0]?.players.find((p: any) => p.isAlive) || null;
-  });
-
-  rightPlayer = computed(() => {
-    if (this.isOneVersusOne()) {
-      const index = this.storedRightPlayerIndex();
-      return this.dataModel.teams()[1]?.players[index] || null;
-    }
-    return this.dataModel.teams()[1]?.players.find((p: any) => p.isAlive) || null;
-  });
+  isOneVersusOne = computed(() => this.oneVsOneService.isOneVersusOne());
+  leftPlayer = computed(() => this.oneVsOneService.leftPlayer());
+  rightPlayer = computed(() => this.oneVsOneService.rightPlayer());
 
   leftPlayerAnimationClass = computed(() => {
-    const index = this.storedLeftPlayerIndex();
+    const index = this.oneVsOneService.leftPlayerIndex();
     if (index === 0) {
       return "animate-1v1-stay";
     }
@@ -90,7 +31,7 @@ export class OneVersusOneComponent implements OnInit {
   });
 
   rightPlayerAnimationClass = computed(() => {
-    const index = this.storedRightPlayerIndex();
+    const index = this.oneVsOneService.rightPlayerIndex();
     if (index === 0) {
       return "animate-1v1-stay";
     }

--- a/src/app/components/combat/player-list/player-list.component.ts
+++ b/src/app/components/combat/player-list/player-list.component.ts
@@ -1,9 +1,10 @@
-import { Component, computed, effect, inject, signal } from "@angular/core";
+import { Component, computed, inject } from "@angular/core";
 import {
   PlayerCombatCardComponent,
   PlayerCombatCardMinimalComponent,
 } from "../player-combat-card/player-combat-card.component";
 import { DataModelService } from "../../../services/dataModel.service";
+import { OneVersusOneService } from "../../../services/1v1.service";
 
 @Component({
   selector: "app-combat-tracker",
@@ -14,37 +15,12 @@ import { DataModelService } from "../../../services/dataModel.service";
 export class CombatPlayerListComponent {
   dataModel = inject(DataModelService);
 
-  private lastRoundNumber = signal<number>(-1);
-  private oneVersusOneTriggered = signal<boolean>(false);
+  readonly oneVsOneService = inject(OneVersusOneService);
 
-  constructor() {
-    // Effect to track round changes and 1v1 state
-    effect(() => {
-      const currentRound = this.dataModel.match().roundNumber;
-      const previousRound = this.lastRoundNumber();
-
-      // Reset 1v1 state when round changes
-      if (currentRound !== previousRound) {
-        this.oneVersusOneTriggered.set(false);
-        this.lastRoundNumber.set(currentRound);
-      }
-
-      // Check if 1v1 condition is met
-      const teams = this.dataModel.teams();
-      const aliveLeft = teams[0].players.filter((p: any) => p.isAlive).length;
-      const aliveRight = teams[1].players.filter((p: any) => p.isAlive).length;
-
-      if (aliveLeft === 1 && aliveRight === 1) {
-        this.oneVersusOneTriggered.set(true);
-      }
-    });
-  }
-
-  isOneVersusOne = computed(() => this.oneVersusOneTriggered());
+  isOneVersusOne = computed(() => this.oneVsOneService.isOneVersusOne());
 
   isShown = computed(() => {
-    const rightPhase = this.dataModel.match().roundPhase !== "shopping";
-    const not1v1 = !this.isOneVersusOne();
-    return rightPhase && not1v1;
+    if (this.dataModel.match().roundPhase == "shopping") return false;
+    return !this.isOneVersusOne();
   });
 }

--- a/src/app/components/combat/playercams/playercams.component.ts
+++ b/src/app/components/combat/playercams/playercams.component.ts
@@ -1,8 +1,9 @@
-import { Component, computed, effect, inject, OnInit, signal } from "@angular/core";
+import { Component, computed, inject, OnInit } from "@angular/core";
 import { SafeResourceUrl } from "@angular/platform-browser";
 import { DataModelService } from "../../../services/dataModel.service";
 import { DisplayNameService } from "../../../services/displayName.service";
 import { PlayercamStreamService } from "../../../services/playercamStream.service";
+import { OneVersusOneService } from "../../../services/1v1.service";
 
 @Component({
   selector: "app-playercams-new",
@@ -13,34 +14,10 @@ import { PlayercamStreamService } from "../../../services/playercamStream.servic
 export class PlayercamsComponent implements OnInit {
   readonly dataModel = inject(DataModelService);
   readonly streamService = inject(PlayercamStreamService);
+  readonly oneVsOneService = inject(OneVersusOneService);
   getDisplayName = inject(DisplayNameService).getDisplayName;
 
-  private lastRoundNumber = signal<number>(-1);
-  private oneVersusOneTriggered = signal<boolean>(false);
-
-  constructor() {
-    // track round changes and 1v1 state
-    effect(() => {
-      const currentRound = this.dataModel.match().roundNumber;
-      const previousRound = this.lastRoundNumber();
-
-      if (currentRound !== previousRound) {
-        this.oneVersusOneTriggered.set(false);
-        this.lastRoundNumber.set(currentRound);
-      }
-
-      // check if 1v1
-      const teams = this.dataModel.teams();
-      const aliveLeft = teams[0].players.filter((p: any) => p.isAlive).length;
-      const aliveRight = teams[1].players.filter((p: any) => p.isAlive).length;
-
-      if (aliveLeft === 1 && aliveRight === 1) {
-        this.oneVersusOneTriggered.set(true);
-      }
-    });
-  }
-
-  isOneVersusOne = computed(() => this.oneVersusOneTriggered());
+  isOneVersusOne = computed(() => this.oneVsOneService.isOneVersusOne());
 
   enabledPlayers = computed(() => {
     let toReturn = this.dataModel.playercamsInfo().enabledPlayers;

--- a/src/app/services/1v1.service.ts
+++ b/src/app/services/1v1.service.ts
@@ -1,0 +1,52 @@
+import { computed, effect, inject, Injectable, signal } from "@angular/core";
+import { DataModelService } from "./dataModel.service";
+
+@Injectable({
+  providedIn: "root",
+})
+export class OneVersusOneService {
+  private dataModel = inject(DataModelService);
+
+  private oneVersusOneTriggered = signal<boolean>(false);
+  private storedLeftPlayerIndex = signal<number>(2);
+  private storedRightPlayerIndex = signal<number>(2);
+
+  constructor() {
+    effect(() => {
+      const teams = this.dataModel.teams();
+      const aliveLeft = teams[0].players.filter((p: any) => p.isAlive).length;
+      const aliveRight = teams[1].players.filter((p: any) => p.isAlive).length;
+
+      if (aliveLeft === 1 && aliveRight === 1) {
+        this.oneVersusOneTriggered.set(true);
+        const leftPlayerIndex = teams[0].players.findIndex((p: any) => p.isAlive);
+        const rightPlayerIndex = teams[1].players.findIndex((p: any) => p.isAlive);
+        this.storedLeftPlayerIndex.set(leftPlayerIndex);
+        this.storedRightPlayerIndex.set(rightPlayerIndex);
+      }
+      if (this.oneVersusOneTriggered() && (aliveLeft >= 2 || aliveRight >= 2)) {
+        this.oneVersusOneTriggered.set(false);
+      }
+    });
+  }
+
+  isOneVersusOne = computed(() => this.oneVersusOneTriggered());
+  leftPlayerIndex = computed(() => this.storedLeftPlayerIndex());
+  rightPlayerIndex = computed(() => this.storedRightPlayerIndex());
+
+  leftPlayer = computed(() => {
+    if (this.isOneVersusOne()) {
+      const index = this.storedLeftPlayerIndex();
+      return this.dataModel.teams()[0]?.players[index] || null;
+    }
+    return this.dataModel.teams()[0]?.players.find((p: any) => p.isAlive) || null;
+  });
+
+  rightPlayer = computed(() => {
+    if (this.isOneVersusOne()) {
+      const index = this.storedRightPlayerIndex();
+      return this.dataModel.teams()[1]?.players[index] || null;
+    }
+    return this.dataModel.teams()[1]?.players.find((p: any) => p.isAlive) || null;
+  });
+}


### PR DESCRIPTION
Why?:
after a 1v1 this.oneVersusOneTriggered never will get set to false and that is a big problem, because you would need to refresh the overlay every time someone gets revived or in the buy phase before the next round.

- [x] fix 1v1 being stuck after a revive or buy phase and some refactoring

the same as https://github.com/ValoSpectra/Spectra-Frontend/pull/36